### PR TITLE
Update the Authorization method for the GitHub API

### DIFF
--- a/chapter-05/photo-share-api/lib.js
+++ b/chapter-05/photo-share-api/lib.js
@@ -22,9 +22,15 @@ const requestGithubToken = credentials =>
     ).then(res => res.json())
 
 const requestGithubUserAccount = token => 
-    fetch(`https://api.github.com/user?access_token=${token}`)
-        .then(res => res.json())
-        
+    fetch(
+        'https://api.github.com/user',
+        {
+            headers: {
+                Authorization: `token ${token}`
+            }
+        }
+    ).then(res => res.json())
+
 const authorizeWithGithub = async credentials => {
     const { access_token } = await requestGithubToken(credentials)
     const githubUser = await requestGithubUserAccount(access_token)

--- a/chapter-06/photo-share-api/lib.js
+++ b/chapter-06/photo-share-api/lib.js
@@ -22,9 +22,15 @@ const requestGithubToken = credentials =>
     ).then(res => res.json())
 
 const requestGithubUserAccount = token => 
-    fetch(`https://api.github.com/user?access_token=${token}`)
-        .then(res => res.json())
-        
+    fetch(
+        'https://api.github.com/user',
+        {
+            headers: {
+                Authorization: `token ${token}`
+            }
+        }
+    ).then(res => res.json())
+
 const authorizeWithGithub = async credentials => {
     const { access_token } = await requestGithubToken(credentials)
     const githubUser = await requestGithubUserAccount(access_token)

--- a/chapter-07/photo-share-api/lib.js
+++ b/chapter-07/photo-share-api/lib.js
@@ -22,9 +22,15 @@ const requestGithubToken = credentials =>
     ).then(res => res.json())
 
 const requestGithubUserAccount = token => 
-    fetch(`https://api.github.com/user?access_token=${token}`)
-        .then(res => res.json())
-        
+    fetch(
+        'https://api.github.com/user',
+        {
+            headers: {
+                Authorization: `token ${token}`
+            }
+        }
+    ).then(res => res.json())
+
 const authorizeWithGithub = async credentials => {
     const { access_token } = await requestGithubToken(credentials)
     const githubUser = await requestGithubUserAccount(access_token)


### PR DESCRIPTION
The way to send `access_token` as a query parameter has
been deprecated and changed to using the `Authorization` header.

See also:
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/

Notes:
- I haven't read chapter 7 yet, so I haven't been able to verify that the code in `chapter-07` works correctly.
